### PR TITLE
Use detox for running tox tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ all: init docs test
 
 init:
 	python setup.py develop
-	pip install tox coverage Sphinx
+	pip install detox coverage Sphinx
 
 test:
 	coverage erase
-	tox
+	detox
 	coverage html
 
 docs: documentation

--- a/README.rst
+++ b/README.rst
@@ -51,19 +51,7 @@ remember to edit the ``<user_or_org_name>`` in the travis and coveralls badge/li
     Running the Tests
     ------------------------------------
     
-    You can run the tests with via::
+    ::
     
-        python setup.py test
-    
-    or::
-    
-        make test
-    
-    or::
-    
-        make all
-    
-    or::
-    
-        python runtests.py
-
+        $ pip install detox
+        $ detox


### PR DESCRIPTION
I removed different ways how to run tests to make instructions easier to comprehend.
