### PR TITLE
Fix django 1.9 warning and drop support django < 1.7

### DIFF
--- a/pinax/app_name/tests/urls.py
+++ b/pinax/app_name/tests/urls.py
@@ -1,10 +1,6 @@
-try:
-    from django.conf.urls import patterns, include
-except ImportError:
-    from django.conf.urls.defaults import patterns, include
+from django.conf.urls import include
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     (r"^", include("pinax.{{ app_name }}.urls")),
-)
+]


### PR DESCRIPTION
Fixes a warning that happens when running with Django 1.9:
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

Drop support of django < 1.7
Remove the ImportError catching because it was a hack for django < 1.7